### PR TITLE
Update pomobar.py with character encoding

### DIFF
--- a/pomobar.py
+++ b/pomobar.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# -*- coding: UTF-8 -*-
 ##############################################################################
 # AUTHOR: [Loopzen](https://github.com/loopzen/)
 # DATE: 2018-10-09


### PR DESCRIPTION
added # -*- coding: UTF-8 -*-
previously was giving the following error:
  File "pomobar.py", line 25
SyntaxError: Non-ASCII character '\xef' in file pomobar.py on line 25, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details